### PR TITLE
Added missing require('fs')

### DIFF
--- a/lib/handle.js
+++ b/lib/handle.js
@@ -1,6 +1,7 @@
 var url = require('url');
 var qs = require('querystring');
 var path = require('path');
+var fs = require('fs');
 
 var services = [ 'upload-pack', 'receive-pack' ]
 


### PR DESCRIPTION
    ...pushover/lib/handle.js:68
            (fs.exists || path.exists)(file, function (ex) {
             ^
    ReferenceError: fs is not defined

https://github.com/substack/pushover/blob/master/lib/handle.js#L68